### PR TITLE
Added default content type for error responses

### DIFF
--- a/src/main/java/io/swagger/inflector/CustomMediaTypes.java
+++ b/src/main/java/io/swagger/inflector/CustomMediaTypes.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2016 SmartBear Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.swagger.inflector;
+
+import javax.ws.rs.core.MediaType;
+
+public class CustomMediaTypes {
+
+    private CustomMediaTypes() {
+    }
+
+    public static MediaType APPLICATION_YAML = new MediaType("application", "yaml");
+}

--- a/src/main/java/io/swagger/inflector/controllers/SwaggerOperationController.java
+++ b/src/main/java/io/swagger/inflector/controllers/SwaggerOperationController.java
@@ -408,10 +408,7 @@ public class SwaggerOperationController extends ReflectionUtils implements Infle
                   final Throwable next = cause.getCause();
                   cause = next == cause || next == null ? null : next;
               }
-              ApiError error = new ApiError()
-                    .message("failed to invoke controller")
-                    .code(500);
-              throw new ApiException(error, e);
+              throw new ApiException(ApiError.createInternalError(), e);
           }
         }
         Map<String, io.swagger.models.Response> responses = operation.getResponses();

--- a/src/main/java/io/swagger/inflector/models/ApiError.java
+++ b/src/main/java/io/swagger/inflector/models/ApiError.java
@@ -16,9 +16,19 @@
 
 package io.swagger.inflector.models;
 
+import javax.ws.rs.core.Response;
+import java.util.concurrent.ThreadLocalRandom;
+
 public class ApiError {
     private int code;
     private String message;
+
+    public static ApiError createInternalError() {
+        final String message = String.format("There was an error processing your request."
+                + " It has been logged (ID: %016x).", ThreadLocalRandom.current().nextLong());
+        return new ApiError().code(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode())
+                .message(message);
+    }
 
     public ApiError code(int code) {
         this.code = code;

--- a/src/main/java/io/swagger/inflector/utils/DefaultMediaTypeProvider.java
+++ b/src/main/java/io/swagger/inflector/utils/DefaultMediaTypeProvider.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2006 SmartBear Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.swagger.inflector.utils;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+
+public class DefaultMediaTypeProvider implements ContextResolver<MediaType> {
+    private final MediaType mediaType;
+
+    public DefaultMediaTypeProvider(MediaType mediaType) {
+        this.mediaType = mediaType;
+    }
+
+    @Override
+    public MediaType getContext(Class<?> type) {
+        return mediaType;
+    }
+}


### PR DESCRIPTION
* Added default content type `JSON/XML` for error responses depending on the order of `json/xml` items in the configuration
* Changed inflector specific error message `failed to invoke controller` to more neutral `There was an error processing your request. It has been logged (ID: XXXXXXXX)`