### PR TITLE
Inject operation definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 hs_err_pid*
 target/
 dependency-reduced-pom.xml
+.settings
+.project
+.classpath

--- a/src/main/java/io/swagger/inflector/config/Configuration.java
+++ b/src/main/java/io/swagger/inflector/config/Configuration.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.inflector.converters.InputConverter;
 import io.swagger.util.Yaml;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +48,7 @@ public class Configuration {
     private List<String> inputConverters = new ArrayList<String>();
     private List<String> inputValidators = new ArrayList<String>();
     private List<String> entityProcessors = new ArrayList<String>();
-    private ControllerFactory controllerFactory = new DefaultControllerFactory();
+    private String controllerFactoryClass;
     private String swaggerBase = "/";
     private Set<Direction> validatePayloads = Collections.emptySet();
 
@@ -174,11 +176,6 @@ public class Configuration {
         return this;
     }
 
-    public Configuration controllerFactory( ControllerFactory instantiator ){
-        this.controllerFactory = instantiator;
-        return this;
-    }
-
     public Configuration swaggerUrl(String swaggerUrl) {
         this.swaggerUrl = swaggerUrl;
         return this;
@@ -200,11 +197,14 @@ public class Configuration {
     }
 
     public ControllerFactory getControllerFactory() {
-        return controllerFactory;
-    }
-
-    public void setControllerFactory(ControllerFactory controllerFactory) {
-        this.controllerFactory = controllerFactory;
+    	if (!StringUtils.isEmpty(controllerFactoryClass)){
+    		try {
+				return Class.forName(controllerFactoryClass).asSubclass(ControllerFactory.class).newInstance();
+			} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+				LOGGER.warn("Couldn't create controller factory.");
+			}
+    	}
+    	return new DefaultControllerFactory();
     }
 
     public void setControllerPackage(String controllerPackage) {
@@ -359,4 +359,12 @@ public class Configuration {
     public void setValidatePayloads(Set<Direction> validatePayloads) {
         this.validatePayloads = validatePayloads;
     }
+
+	public String getControllerFactoryClass() {
+		return controllerFactoryClass;
+	}
+
+	public void setControllerFactoryClass(String controllerFactoryClass) {
+		this.controllerFactoryClass = controllerFactoryClass;
+	}
 }

--- a/src/main/java/io/swagger/inflector/config/ControllerFactory.java
+++ b/src/main/java/io/swagger/inflector/config/ControllerFactory.java
@@ -16,6 +16,8 @@
 
 package io.swagger.inflector.config;
 
+import io.swagger.models.Operation;
+
 /**
  * Behaviour for instantiating controllers - provide your custom implementation to the Configuration
  * class for hooking into DI frameworks, script engines, etc
@@ -27,10 +29,11 @@ public interface ControllerFactory {
      * Instantiates the provided controller class
      *
      * @param cls the class to instantiate
+     * @param operation the operation to instantiate
      * @return an instance of the class
      * @throws IllegalAccessException
      * @throws InstantiationException
      */
 
-    Object instantiateController(Class<? extends Object> cls) throws IllegalAccessException, InstantiationException;
+    Object instantiateController(Class<? extends Object> cls, Operation operation) throws IllegalAccessException, InstantiationException;
 }

--- a/src/main/java/io/swagger/inflector/config/DefaultControllerFactory.java
+++ b/src/main/java/io/swagger/inflector/config/DefaultControllerFactory.java
@@ -16,6 +16,8 @@
 
 package io.swagger.inflector.config;
 
+import io.swagger.models.Operation;
+
 /**
  * Default ControllerFactory implementation that just calls newInstance
  */
@@ -26,13 +28,14 @@ public class DefaultControllerFactory implements ControllerFactory {
      * Instantiates the provided class calling cls.newInstance()
      *
      * @param cls the class to be instantiated
+     * @param operation the operation to instantiate
      * @return an instance of the provided class
      * @throws IllegalAccessException
      * @throws InstantiationException
      */
 
     @Override
-    public Object instantiateController(Class<? extends Object> cls) throws IllegalAccessException, InstantiationException {
+    public Object instantiateController(Class<? extends Object> cls, Operation operation) throws IllegalAccessException, InstantiationException {
         return cls.newInstance();
     }
 }

--- a/src/main/java/io/swagger/inflector/controllers/SwaggerOperationController.java
+++ b/src/main/java/io/swagger/inflector/controllers/SwaggerOperationController.java
@@ -19,6 +19,7 @@ package io.swagger.inflector.controllers;
 import com.fasterxml.jackson.databind.JavaType;
 import com.google.common.io.Files;
 import io.swagger.inflector.config.Configuration;
+import io.swagger.inflector.config.ControllerFactory;
 import io.swagger.inflector.converters.ConversionException;
 import io.swagger.inflector.converters.InputConverter;
 import io.swagger.inflector.examples.ExampleBuilder;
@@ -95,6 +96,7 @@ public class SwaggerOperationController extends ReflectionUtils implements Infle
     private Provider<Providers> providersProvider;
     @Inject
     private Provider<HttpServletRequest> requestProvider;
+    private ControllerFactory controllerFactoryCache = null;
 
     public SwaggerOperationController(Configuration config, String path, String httpMethod, Operation operation, Map<String, Model> definitions) {
         this.setConfiguration(config);
@@ -166,7 +168,7 @@ public class SwaggerOperationController extends ReflectionUtils implements Infle
                             }
                             if (matched) {
                                 this.parameterClasses = args;
-                                this.controller = config.getControllerFactory().instantiateController(cls, operation);
+                                this.controller = getControllerFactory().instantiateController(cls, operation);
                                 LOGGER.debug("found class `" + controllerName + "`");
                                 return method;
                             }
@@ -696,5 +698,12 @@ public class SwaggerOperationController extends ReflectionUtils implements Infle
                 }
                 break;
         }
+    }
+    
+    private ControllerFactory getControllerFactory() {
+    	if (controllerFactoryCache == null){
+    		controllerFactoryCache = config.getControllerFactory();
+    	}
+    	return controllerFactoryCache;
     }
 }

--- a/src/main/java/io/swagger/inflector/controllers/SwaggerOperationController.java
+++ b/src/main/java/io/swagger/inflector/controllers/SwaggerOperationController.java
@@ -166,7 +166,7 @@ public class SwaggerOperationController extends ReflectionUtils implements Infle
                             }
                             if (matched) {
                                 this.parameterClasses = args;
-                                this.controller = config.getControllerFactory().instantiateController(cls);
+                                this.controller = config.getControllerFactory().instantiateController(cls, operation);
                                 LOGGER.debug("found class `" + controllerName + "`");
                                 return method;
                             }


### PR DESCRIPTION
The changes are below:

1. Allowing using custom controller factory classes.
Devloper can use the key "controllerFactoryClass" to define the controller factory class in their inflector.yaml config file. The controller factory class would be lazy loaded and cached inside SwaggerOperationController.java during controller class initialization.

2. Adding the operation definition object as the Controller factory initializing controller parameter. Hence, developer can have more information about the operation current processing on in their factory class. It provide more flexibility to let developers to do add on logic on their controllers.