### PR TITLE
restore of deleted setter in swagger-api/swagger-inflector#122

### DIFF
--- a/src/main/java/io/swagger/inflector/config/Configuration.java
+++ b/src/main/java/io/swagger/inflector/config/Configuration.java
@@ -21,14 +21,19 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.inflector.converters.InputConverter;
 import io.swagger.util.Yaml;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class Configuration {
     private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
@@ -48,7 +53,7 @@ public class Configuration {
     private List<String> inputConverters = new ArrayList<String>();
     private List<String> inputValidators = new ArrayList<String>();
     private List<String> entityProcessors = new ArrayList<String>();
-    private String controllerFactoryClass;
+    private ControllerFactory controllerFactory = new DefaultControllerFactory();
     private String swaggerBase = "/";
     private Set<Direction> validatePayloads = Collections.emptySet();
 
@@ -197,14 +202,7 @@ public class Configuration {
     }
 
     public ControllerFactory getControllerFactory() {
-    	if (!StringUtils.isEmpty(controllerFactoryClass)){
-    		try {
-				return Class.forName(controllerFactoryClass).asSubclass(ControllerFactory.class).newInstance();
-			} catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-				LOGGER.warn("Couldn't create controller factory.");
-			}
-    	}
-    	return new DefaultControllerFactory();
+        return controllerFactory;
     }
 
     public void setControllerPackage(String controllerPackage) {
@@ -360,11 +358,22 @@ public class Configuration {
         this.validatePayloads = validatePayloads;
     }
 
-	public String getControllerFactoryClass() {
-		return controllerFactoryClass;
-	}
+    public String getControllerFactoryClass() {
+        return controllerFactory.getClass().getName();
+    }
 
 	public void setControllerFactoryClass(String controllerFactoryClass) {
-		this.controllerFactoryClass = controllerFactoryClass;
-	}
+        if (!StringUtils.isEmpty(controllerFactoryClass)) {
+            try {
+                controllerFactory = Class.forName(controllerFactoryClass).asSubclass(ControllerFactory.class)
+                        .newInstance();
+            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+                LOGGER.error("Couldn't create controller factory", e);
+            }
+        }
+    }
+
+    public void setControllerFactory(ControllerFactory controllerFactory) {
+        this.controllerFactory = controllerFactory;
+    }
 }

--- a/src/test/java/io/swagger/inflector/config/ConfigurationTest.java
+++ b/src/test/java/io/swagger/inflector/config/ConfigurationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.swagger.inflector.config;
+
+import io.swagger.models.Operation;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ConfigurationTest {
+
+    @Test
+    public void defaultControllerFactoryTest() {
+        Assert.assertEquals(new Configuration().getControllerFactory().getClass(), DefaultControllerFactory.class);
+    }
+
+    @Test
+    public void controllerFactoryFromClassNameTest() {
+        final Configuration configuration = new Configuration();
+        configuration.setControllerFactoryClass(ControllerFactoryImpl.class.getName());
+
+        Assert.assertEquals(configuration.getControllerFactory().getClass(), ControllerFactoryImpl.class);
+    }
+
+    @Test
+    public void controllerFactoryFromInstanceNameTest() {
+        final Configuration configuration = new Configuration();
+        configuration.setControllerFactory(new ControllerFactoryImpl());
+
+        Assert.assertEquals(configuration.getControllerFactory().getClass(), ControllerFactoryImpl.class);
+    }
+
+    public static class ControllerFactoryImpl implements ControllerFactory {
+        @Override
+        public Object instantiateController(Class<? extends Object> cls,
+                Operation operation) throws IllegalAccessException, InstantiationException {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
In https://github.com/swagger-api/swagger-inflector/pull/122 `public void setControllerFactory(ControllerFactory controllerFactory)` was deleted, but someone could use it.