### PR TITLE
Set pretty printing according user configurations on filter

### DIFF
--- a/src/main/java/io/swagger/inflector/SwaggerInflector.java
+++ b/src/main/java/io/swagger/inflector/SwaggerInflector.java
@@ -179,7 +179,7 @@ public class SwaggerInflector extends ResourceConfig {
                 Json.mapper().registerModule(simpleModule);
                 register(JacksonJsonProvider.class);
                 register(JsonExampleProvider.class);
-                register(JsonProvider.class);
+                register(new JsonProvider(config.isPrettyPrint()));
                 if (!isRegistered(DefaultContentTypeProvider.class)) {
                     register(new DefaultContentTypeProvider(MediaType.APPLICATION_JSON_TYPE),
                             ContextResolver.class);
@@ -208,6 +208,7 @@ public class SwaggerInflector extends ResourceConfig {
 
         // Swagger serializers
         register(SwaggerSerializers.class);
+        SwaggerSerializers.setPrettyPrint(config.isPrettyPrint());
 
         for (Class<?> exceptionMapper : config.getExceptionMappers()) {
             register(exceptionMapper);

--- a/src/main/java/io/swagger/inflector/config/Configuration.java
+++ b/src/main/java/io/swagger/inflector/config/Configuration.java
@@ -56,6 +56,7 @@ public class Configuration {
     private ControllerFactory controllerFactory = new DefaultControllerFactory();
     private String swaggerBase = "/";
     private Set<Direction> validatePayloads = Collections.emptySet();
+    private boolean prettyPrint;
 
     public String getSwaggerBase() {
         if("".equals(swaggerBase) || "/".equals(swaggerBase)) {
@@ -384,5 +385,13 @@ public class Configuration {
 
     public void setControllerFactory(ControllerFactory controllerFactory) {
         this.controllerFactory = controllerFactory;
+    }
+
+    public boolean isPrettyPrint() {
+        return prettyPrint;
+    }
+
+    public void setPrettyPrint(boolean prettyPrint) {
+        this.prettyPrint = prettyPrint;
     }
 }

--- a/src/main/java/io/swagger/inflector/processors/JsonProvider.java
+++ b/src/main/java/io/swagger/inflector/processors/JsonProvider.java
@@ -1,6 +1,7 @@
 package io.swagger.inflector.processors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import io.swagger.util.Json;
 
 import javax.ws.rs.ext.ContextResolver;
@@ -9,13 +10,23 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class JsonProvider implements ContextResolver<ObjectMapper> {
     private final ObjectMapper objectMapper;
+    private boolean prettyPrint;
 
     public JsonProvider() {
         objectMapper = Json.mapper();
-    };
+    }
+
+    public JsonProvider(boolean prettyPrint) {
+        this();
+        this.prettyPrint = prettyPrint;
+    }
 
     @Override
     public ObjectMapper getContext(Class<?> type) {
+        if(this.prettyPrint) {
+            objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        }
+
         return objectMapper;
     }
 }

--- a/src/main/java/io/swagger/inflector/utils/CORSFilter.java
+++ b/src/main/java/io/swagger/inflector/utils/CORSFilter.java
@@ -16,8 +16,6 @@
 
 package io.swagger.inflector.utils;
 
-import io.swagger.jaxrs.listing.SwaggerSerializers;
-
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
@@ -43,6 +41,5 @@ public class CORSFilter implements javax.servlet.Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        SwaggerSerializers.setPrettyPrint(Boolean.parseBoolean(filterConfig.getInitParameter("swagger.pretty.print")));
     }
 }

--- a/src/main/java/io/swagger/inflector/utils/CORSFilter.java
+++ b/src/main/java/io/swagger/inflector/utils/CORSFilter.java
@@ -16,6 +16,8 @@
 
 package io.swagger.inflector.utils;
 
+import io.swagger.jaxrs.listing.SwaggerSerializers;
+
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
@@ -41,5 +43,6 @@ public class CORSFilter implements javax.servlet.Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
+        SwaggerSerializers.setPrettyPrint(Boolean.parseBoolean(filterConfig.getInitParameter("swagger.pretty.print")));
     }
 }


### PR DESCRIPTION
This PR has been created to add pretty printing based on project configuration, to enable the pretty printing an **init-param** should be added to the filter.

```xml
<filter>
    <filter-name>CORSFilter</filter-name>
    <filter-class>io.swagger.inflector.utils.CORSFilter</filter-class>
    <init-param>
        <param-name>swagger.pretty.print</param-name>
        <param-value>true</param-value>
    </init-param>
</filter>
```