### PR TITLE
Addresses issue #161 by allowing a custom ObjectMapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,7 +456,7 @@
     <properties>
         <swagger-core-version>1.5.10</swagger-core-version>
         <swagger-parser-version>1.0.24-SNAPSHOT</swagger-parser-version>
-        <jackson.version>2.7.8</jackson.version>
+        <jackson.version>2.8.5</jackson.version>
         <joda-time-version>2.2</joda-time-version>
         <joda-version>1.2</joda-version>
         <jetty-version>9.2.9.v20150224</jetty-version>

--- a/src/main/java/io/swagger/inflector/SwaggerInflector.java
+++ b/src/main/java/io/swagger/inflector/SwaggerInflector.java
@@ -16,6 +16,8 @@
 
 package io.swagger.inflector;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.fasterxml.jackson.jaxrs.xml.JacksonJaxbXMLProvider;
@@ -65,7 +67,15 @@ public class SwaggerInflector extends ResourceConfig {
     private Map<String, List<String>> missingOperations = new HashMap<String, List<String>>();
     private Set<String> unimplementedMappedModels = new TreeSet<String>();
 
+    private ObjectMapper objectMapper;
+
     public SwaggerInflector(Configuration configuration) {
+        this(configuration, Json.mapper());
+    }
+
+    public SwaggerInflector(Configuration configuration,ObjectMapper objectMapper)
+    {
+        this.objectMapper = objectMapper;
         init(configuration);
     }
 
@@ -85,7 +95,12 @@ public class SwaggerInflector extends ResourceConfig {
             // use default location
             config = Configuration.read();
         }
+        objectMapper = Json.mapper();
         init(config);
+    }
+
+    protected ObjectMapper getObjectMapper() {
+        return objectMapper;
     }
 
     protected void init(Configuration configuration) {
@@ -176,10 +191,16 @@ public class SwaggerInflector extends ResourceConfig {
         for (String item : config.getEntityProcessors()) {
             if ("json".equalsIgnoreCase(item)) {
                 // JSON
-                Json.mapper().registerModule(simpleModule);
+                getObjectMapper().registerModule(simpleModule);
                 register(JacksonJsonProvider.class);
                 register(JsonExampleProvider.class);
-                register(new JsonProvider(config.isPrettyPrint()));
+
+                // If a custom object mapper has this INDENT_OUTPUT specified already,
+                // disable the the JsonProvider as it's redundant
+                if(!getObjectMapper().isEnabled(SerializationFeature.INDENT_OUTPUT))
+                {
+                    register(new JsonProvider(config.isPrettyPrint()));
+                }
                 if (!isRegistered(DefaultContentTypeProvider.class)) {
                     register(new DefaultContentTypeProvider(MediaType.APPLICATION_JSON_TYPE),
                             ContextResolver.class);

--- a/src/test/java/io/swagger/inflector/SwaggerInflectorTest.java
+++ b/src/test/java/io/swagger/inflector/SwaggerInflectorTest.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2015 SmartBear Software
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.swagger.inflector;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.swagger.inflector.SwaggerInflector;
+import io.swagger.inflector.config.Configuration;
+import io.swagger.inflector.processors.JsonProvider;
+import io.swagger.util.Json;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+
+;import static org.testng.Assert.*;
+
+
+public class SwaggerInflectorTest {
+
+    Configuration config;
+
+    @BeforeTest
+    public void before()
+    {
+        System.setProperty("config", "src/test/config/config1.yaml");
+        config = Configuration.read();
+    }
+
+    @Test
+    public void testLoadWithDefaultObjectMapper() throws Exception {
+        SwaggerInflector inflector = new SwaggerInflector(config);
+        assertEquals(Json.mapper(),inflector.getObjectMapper());
+        assertTrue(inflector.isRegistered(JsonProvider.class));
+    }
+
+
+    @Test
+    public void testLoadWithCustomObjectMapper() throws Exception {
+        // ensure that pretty print is enabled
+        config.setPrettyPrint(true);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+        SwaggerInflector inflector = new SwaggerInflector(config,objectMapper);
+        assertEquals(objectMapper,inflector.getObjectMapper());
+        assertNotEquals(Json.mapper(),inflector.getObjectMapper());
+        // This class SHOULD NOT be registered since the custom mapper
+        // is providing this functionality.
+        assertFalse(inflector.isRegistered(JsonProvider.class));
+    }
+}


### PR DESCRIPTION
This change addresses issue #161 and allows one to provide a custom ObjectMapper. In non-servlet environments such as Spring Boot and Dropwizard, there's a new constructor that allows one to pass in a pre-configured ObjectMapper.  