### PR TITLE
Use full HTTPS URL in setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You have full control over the mapping of controllers to classes and methods as 
 
 Run this command to start in a hurry.  It will create a project named `my-project`
 ```
-curl -L http://bit.ly/1Pl62pe | project=my-project bash
+curl -L https://raw.githubusercontent.com/swagger-api/swagger-inflector/master/setup.sh | project=my-project bash
 ```
 
 This will download everything you need to start editing and running a swagger-inflector based project.  See the output of the command for instructions.


### PR DESCRIPTION
For something as security-sensitive as piping a downloaded command to bash, using a shortened URL as well as an HTTP URL is reckless. Copy-pasting a slightly longer URL is no more effort, is safer, doesn't require the user to trust a large number of third parties, and adds credibility to your project.