### PR TITLE
fixing explode bug in spec

### DIFF
--- a/src/test/swagger/oas3.yaml
+++ b/src/test/swagger/oas3.yaml
@@ -254,6 +254,7 @@ paths:
         in: query
         required: true
         style: form
+        explode: false
         schema:
           type: array
           items:


### PR DESCRIPTION
This fixes a bug in oas3.yaml spec, where a query parameter had no explode attribute set.