### PR TITLE
Support for schema as Model in Response Object - refs swagger-api/swagger-parser #567

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,8 +429,8 @@
         </dependency>
     </dependencies>
     <properties>
-        <swagger-core-version>1.5.18-SNAPSHOT</swagger-core-version>
-        <swagger-parser-version>1.0.34-SNAPSHOT</swagger-parser-version>
+        <swagger-core-version>1.5.19-SNAPSHOT</swagger-core-version>
+        <swagger-parser-version>1.0.35-SNAPSHOT</swagger-parser-version>
         <jackson.version>2.8.7</jackson.version>
         <joda-time-version>2.9.1</joda-time-version>
         <joda-version>1.8.1</joda-version>

--- a/pom.xml
+++ b/pom.xml
@@ -429,8 +429,8 @@
         </dependency>
     </dependencies>
     <properties>
-        <swagger-core-version>1.5.15</swagger-core-version>
-        <swagger-parser-version>1.0.30</swagger-parser-version>
+        <swagger-core-version>1.5.18-SNAPSHOT</swagger-core-version>
+        <swagger-parser-version>1.0.34-SNAPSHOT</swagger-parser-version>
         <jackson.version>2.8.7</jackson.version>
         <joda-time-version>2.9.1</joda-time-version>
         <joda-version>1.8.1</joda-version>

--- a/src/main/java/io/swagger/inflector/controllers/SwaggerOperationController.java
+++ b/src/main/java/io/swagger/inflector/controllers/SwaggerOperationController.java
@@ -525,8 +525,8 @@ public class SwaggerOperationController extends ReflectionUtils implements Infle
                                     // try default response schema
                                     responseSchema = operation.getResponses().get("default");
                                 }
-                                if (responseSchema != null && responseSchema.getSchema() != null) {
-                                    validate(wrapper.getEntity(), responseSchema.getSchema(), SchemaValidator.Direction.OUTPUT);
+                                if (responseSchema != null && responseSchema.getResponseSchema() != null) {
+                                    validate(wrapper.getEntity(), responseSchema.getResponseSchema(), SchemaValidator.Direction.OUTPUT);
                                 } else {
                                     LOGGER.debug("no response schema for code " + responseCode + " to validate against");
                                 }

--- a/src/main/java/io/swagger/inflector/examples/ExampleBuilder.java
+++ b/src/main/java/io/swagger/inflector/examples/ExampleBuilder.java
@@ -393,7 +393,7 @@ public class ExampleBuilder {
                     }
                     if (model.getExample() != null) {
                         try {
-                            Example n = Json.mapper().readValue(model.getExample().toString(), Example.class);
+                            Example n = Json.mapper().readValue(Json.mapper().writeValueAsString(example), Example.class);
                             output = n;
                         } catch (IOException e) {
                             LOGGER.error("unable to convert value", e);
@@ -486,7 +486,7 @@ public class ExampleBuilder {
         Example output = null;
         if (model.getExample() != null) {
             try {
-                String str = model.getExample().toString();
+                String str = Json.mapper().writeValueAsString(model.getExample());
                 output = Json.mapper().readValue(str, ObjectExample.class);
             } catch (IOException e) {
                 return null;

--- a/src/main/java/io/swagger/inflector/examples/ExampleBuilder.java
+++ b/src/main/java/io/swagger/inflector/examples/ExampleBuilder.java
@@ -326,7 +326,7 @@ public class ExampleBuilder {
         } else if (property instanceof ArrayProperty) {
             if (example != null) {
                 try {
-                    output = Json.mapper().readValue(example.toString(), ArrayExample.class);
+                    output = Json.mapper().readValue(Json.mapper().writeValueAsString(example), ArrayExample.class);
                 } catch (IOException e) {
                     LOGGER.error("unable to convert `" + example + "` to JsonNode");
                     output = new ArrayExample();

--- a/src/main/java/io/swagger/inflector/examples/ExampleBuilder.java
+++ b/src/main/java/io/swagger/inflector/examples/ExampleBuilder.java
@@ -30,6 +30,7 @@ import io.swagger.models.ArrayModel;
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
+import io.swagger.models.RefModel;
 import io.swagger.models.Xml;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.BaseIntegerProperty;
@@ -303,7 +304,7 @@ public class ExampleBuilder {
         } else if (property instanceof ObjectProperty) {
             if (example != null) {
                 try {
-                    output = Json.mapper().readValue(example.toString(), ObjectExample.class);
+                    output = Json.mapper().readValue(Json.mapper().writeValueAsString(example), ObjectExample.class);
                 } catch (IOException e) {
                     LOGGER.error("unable to convert `" + example + "` to JsonNode");
                     output = new ObjectExample();
@@ -434,6 +435,7 @@ public class ExampleBuilder {
         }
         return output;
     }
+
 
     public static Example alreadyProcessedRefExample(String name, Map<String, Model> definitions) {
         Model model = definitions.get(name);

--- a/src/main/java/io/swagger/inflector/utils/ResolverUtil.java
+++ b/src/main/java/io/swagger/inflector/utils/ResolverUtil.java
@@ -74,9 +74,9 @@ public class ResolverUtil {
                 if(op.getResponses() != null) {
                     for(String code : op.getResponses().keySet()) {
                         Response response = op.getResponses().get(code);
-                        if (response.getSchema() != null) {
-                            Property resolved = resolveFully(response.getSchema());
-                            response.setSchema(resolved);
+                        if (response.getResponseSchema() != null) {
+                            Model resolved = resolveFully(response.getResponseSchema());
+                            response.setResponseSchema(resolved);
                         }
                     }
                 }


### PR DESCRIPTION
Support for schema as Model in Response Object - refs swagger-api/swagger-parser #567
Depends on: swagger-api/swagger-parser #342 - replacing getSchema method