### PR TITLE
Support an allOf containing refs

### DIFF
--- a/src/main/java/io/swagger/inflector/examples/ExampleBuilder.java
+++ b/src/main/java/io/swagger/inflector/examples/ExampleBuilder.java
@@ -30,6 +30,7 @@ import io.swagger.models.ArrayModel;
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
+import io.swagger.models.RefModel;
 import io.swagger.models.Xml;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.BaseIntegerProperty;
@@ -535,6 +536,21 @@ public class ExampleBuilder {
                     ArrayExample an = new ArrayExample();
                     an.add(innerExample);
                     output = an;
+                }
+            }
+        }
+        else if(model instanceof RefModel) {
+            RefModel ref = (RefModel) model;
+            if(processedModels.contains(ref.getSimpleRef())) {
+                // return some sort of example
+                output = alreadyProcessedRefExample(ref.getSimpleRef(), definitions);
+            } else {
+                processedModels.add(ref.getSimpleRef());
+                if (definitions != null) {
+                    Model refedModel = definitions.get(ref.getSimpleRef());
+                    if (refedModel != null) {
+                        output = fromModel(ref.getSimpleRef(), refedModel, definitions, processedModels);
+                    }
                 }
             }
         }

--- a/src/test/java/io/swagger/test/examples/ExampleBuilderTest.java
+++ b/src/test/java/io/swagger/test/examples/ExampleBuilderTest.java
@@ -529,10 +529,7 @@ public class ExampleBuilderTest {
     public void testObjectsWithAnonymousObjectArrays() throws Exception {
         Swagger swagger = new SwaggerParser().read("src/test/swagger/issue-171.yaml");
 
-        Response response = swagger.getPath("/test").getGet().getResponses().get( "200" );
-        Example example = ExampleBuilder.fromProperty(response.getSchema(), swagger.getDefinitions());
-
-        String output = Json.pretty(example);
+        String output = getExampleForPath(swagger, "/test");
 
         assertEqualsIgnoreLineEnding(output, "[ {\n" +
                 "  \"id\" : \"string\",\n" +
@@ -543,8 +540,8 @@ public class ExampleBuilderTest {
                 "} ]");
 
 
-        response = swagger.getPath("/anothertest").getGet().getResponses().get( "200" );
-        example = ExampleBuilder.fromProperty(response.getSchema(), swagger.getDefinitions());
+        Response response = swagger.getPath("/anothertest").getGet().getResponses().get( "200" );
+        Example example = ExampleBuilder.fromProperty(response.getSchema(), swagger.getDefinitions());
 
         output = new XmlExampleSerializer().serialize(example);
         assertEquals( output, "<?xml version='1.1' encoding='UTF-8'?><string>string</string>");
@@ -554,10 +551,7 @@ public class ExampleBuilderTest {
     public void testEnumExample() throws Exception {
         Swagger swagger = new SwaggerParser().read("src/test/swagger/issue-171.yaml");
 
-        Response response = swagger.getPath("/color").getGet().getResponses().get("200");
-        Example example = ExampleBuilder.fromProperty(response.getSchema(), swagger.getDefinitions());
-
-        String output = Json.pretty(example);
+        String output = getExampleForPath(swagger, "/color");
         assertEqualsIgnoreLineEnding(output, "{\n" +
                 "  \"color\" : \"black\"\n" +
                 "}");
@@ -567,10 +561,7 @@ public class ExampleBuilderTest {
     public void testIssue1261InlineSchemaExample() throws Exception {
         Swagger swagger = new SwaggerParser().read("src/test/swagger/issue-1261.yaml");
 
-        Response response = swagger.getPath("/user").getGet().getResponses().get("200");
-        Example example = ExampleBuilder.fromProperty(response.getSchema(), swagger.getDefinitions());
-
-        String output = Json.pretty(example);
+        String output = getExampleForPath(swagger, "/user");
         assertEqualsIgnoreLineEnding(output, "{\n" +
                 "  \"id\" : 42,\n" +
                 "  \"name\" : \"Arthur Dent\"\n" +
@@ -581,10 +572,7 @@ public class ExampleBuilderTest {
     public void testIssue1177RefArrayExample() throws Exception {
         Swagger swagger = new SwaggerParser().read("src/test/swagger/issue-1177.yaml");
 
-        Response response = swagger.getPath("/array").getGet().getResponses().get("200");
-        Example example = ExampleBuilder.fromProperty(response.getSchema(), swagger.getDefinitions());
-
-        String output = Json.pretty(example);
+        String output = getExampleForPath(swagger, "/array");
         assertEqualsIgnoreLineEnding(output, "[ \"string\" ]");
     }
 
@@ -592,10 +580,7 @@ public class ExampleBuilderTest {
     public void testIssue1263SchemaExampleNestedObjects() throws Exception {
         Swagger swagger = new SwaggerParser().read("src/test/swagger/issue-1263.yaml");
 
-        Response response = swagger.getPath("/nested_object").getGet().getResponses().get("200");
-        Example example = ExampleBuilder.fromProperty(response.getSchema(), swagger.getDefinitions());
-
-        String output = Json.pretty(example);
+        String output = getExampleForPath(swagger, "/nested_object");
         assertEqualsIgnoreLineEnding(output, "{\n" +
                 "  \"nested_object\" : {\n" +
                 "    \"foo\" : \"bar\"\n" +
@@ -607,10 +592,7 @@ public class ExampleBuilderTest {
     public void testDifferentExampleTypes() throws Exception {
         Swagger swagger = new SwaggerParser().read("src/test/swagger/example-types.yaml");
 
-        Response response = swagger.getPath("/user").getGet().getResponses().get("200");
-        Example example = ExampleBuilder.fromProperty(response.getSchema(), swagger.getDefinitions());
-
-        String output = Json.pretty(example);
+        String output = getExampleForPath(swagger, "/user");
         assertEqualsIgnoreLineEnding(output, "{\n" +
                 "  \"obj\" : {\n" +
                 "    \"b\" : \"ho\",\n" +
@@ -624,5 +606,22 @@ public class ExampleBuilderTest {
                 "  \"boolean\" : true,\n" +
                 "  \"string\" : \"Arthur Dent\"\n" +
                 "}");
+    }
+
+    @Test
+    public void testAllOfAndRef() throws Exception {
+        Swagger swagger = new SwaggerParser().read("src/test/swagger/allOfAndRef.yaml");
+
+        String output = getExampleForPath(swagger, "/refToAllOf");
+        assertEqualsIgnoreLineEnding(output, "{\n" +
+                "  \"username\" : \"trillian\",\n" +
+                "  \"id\" : 4\n" +
+                "}");
+    }
+
+    private String getExampleForPath(Swagger swagger, String s) {
+        Response response = swagger.getPath(s).getGet().getResponses().get("200");
+        Example example = ExampleBuilder.fromProperty(response.getSchema(), swagger.getDefinitions());
+        return Json.pretty(example);
     }
 }

--- a/src/test/swagger/allOfAndRef.yaml
+++ b/src/test/swagger/allOfAndRef.yaml
@@ -1,0 +1,35 @@
+swagger: '2.0'
+info:
+  version: "0.1.1"
+  title: VirtServer, allOf and $ref
+
+produces:
+  - application/json
+
+paths:
+  /refToAllOf:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/UserEx'
+
+definitions:
+  User:
+    type: object
+    properties:
+      username:
+        type: string
+        example: trillian
+    required: [username]
+
+  UserEx:
+    allOf:
+      - $ref: '#/definitions/User'
+      - type: object
+        properties:
+          id:
+            type: integer
+            example: 4
+        required: [id]


### PR DESCRIPTION
I copied the logic from a RefProperty and applied it to a RefModel. Could there be some reason this wasn't added before which I missed?