### PR TITLE
Handle schema examples with null properties

### DIFF
--- a/src/main/java/io/swagger/oas/inflector/processors/JsonExampleDeserializer.java
+++ b/src/main/java/io/swagger/oas/inflector/processors/JsonExampleDeserializer.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.FloatNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ShortNode;
 import io.swagger.oas.inflector.examples.models.ArrayExample;
@@ -88,6 +89,8 @@ public class JsonExampleDeserializer extends JsonDeserializer<Example> {
             return new LongExample(node.longValue());
         } else if (node instanceof BooleanNode) {
             return new BooleanExample(node.booleanValue());
+        } else if (node instanceof NullNode) {
+            return new StringExample(null);
         } else {
             return new StringExample(node.asText());
         }

--- a/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
+++ b/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
@@ -780,4 +780,22 @@ public class ExampleBuilderTest {
         Assert.assertNotNull(openAPI.getComponents().getSchemas().get("User"));
         Assert.assertTrue(openAPI.getPaths().get("/refToAllOf").getGet().getResponses().get("200").getContent().get("application/json").getSchema().getProperties().size() == 2);
     }
+
+    @Test
+    public void schemaExampleWithNullProperty(@Injectable final List<AuthorizationValue> auths) throws Exception {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setResolveFully(true);
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/schemaExampleWithNullProperty.yaml",auths,options);
+
+        Assert.assertNotNull(openAPI);
+        ApiResponse apiResponse = openAPI.getPaths().get("/schemaExampleWithNullProperty").getGet().getResponses().get("200");
+        Example example = ExampleBuilder.fromSchema(apiResponse.getContent().get("application/json").getSchema(),null,ExampleBuilder.RequestType.READ);
+        String output = Json.pretty(example);
+        assertEqualsIgnoreLineEnding(output, "{\n" +
+                "  \"prop1\" : null,\n" +
+                "  \"prop2\" : null,\n" +
+                "  \"prop3\" : null\n" +
+                "}");
+    }
 }

--- a/src/test/swagger/schemaExampleWithNullProperty.yaml
+++ b/src/test/swagger/schemaExampleWithNullProperty.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  version: 0.0.0
+paths:
+  /schemaExampleWithNullProperty:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                example:
+                  prop1: null
+                  prop2: ~
+                  prop3:


### PR DESCRIPTION
We had problem with examples for the following spec
```
openapi: 3.0.0
info:
  version: 0.0.0
paths:
  /schemaExampleWithNullProperty:
    get:
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                type: object
                example:
                  prop1: null
                  prop2: ~
                  prop3:
```

**Expect**
```
{
  "prop1": null,
  "prop2": null,
  "prop3": null
}
```

**Actual**
```
{
  "prop1": "null",
  "prop2": "null",
  "prop3": "null"
}
```

Adding the check for `NullNode` in the example deserializer should fix it.