### PR TITLE
Add request and response objects to RequestContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,8 +429,8 @@
         </dependency>
     </dependencies>
     <properties>
-        <swagger-core-version>1.5.20-SNAPSHOT</swagger-core-version>
-        <swagger-parser-version>1.0.36-SNAPSHOT</swagger-parser-version>
+        <swagger-core-version>1.5.20</swagger-core-version>
+        <swagger-parser-version>1.0.36</swagger-parser-version>
         <jackson.version>2.8.7</jackson.version>
         <joda-time-version>2.9.1</joda-time-version>
         <joda-version>1.8.1</joda-version>

--- a/src/main/java/io/swagger/inflector/models/RequestContext.java
+++ b/src/main/java/io/swagger/inflector/models/RequestContext.java
@@ -16,6 +16,8 @@
 
 package io.swagger.inflector.models;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
@@ -27,16 +29,29 @@ public class RequestContext {
     MediaType mediaType;
     List<MediaType> acceptableMediaTypes;
     private String remoteAddr;
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
 
-    public RequestContext() {}
+    public RequestContext() {
+        this(null, null, null);
+    }
 
-    public RequestContext(ContainerRequestContext ctx) {
-        this.context = ctx;
-        if(ctx != null) {
-            headers(ctx.getHeaders());
-            mediaType(ctx.getMediaType());
-            acceptableMediaTypes(ctx.getAcceptableMediaTypes());
+    public RequestContext(ContainerRequestContext context) {
+        this(context, null, null);
+    }
+
+    public RequestContext(ContainerRequestContext context, HttpServletRequest request, HttpServletResponse response) {
+        this.context = context;
+        if(context != null) {
+            headers(context.getHeaders());
+            mediaType(context.getMediaType());
+            acceptableMediaTypes(context.getAcceptableMediaTypes());
         }
+        this.request = request;
+        if (request != null) {
+            this.remoteAddr = request.getRemoteAddr();
+        }
+        this.response = response;
     }
 
     public RequestContext headers(MultivaluedMap<String, String> headers) {
@@ -92,5 +107,13 @@ public class RequestContext {
 
     public void setRemoteAddr(String remoteAddr) {
         this.remoteAddr = remoteAddr;
+    }
+
+    public HttpServletRequest getRequest() {
+        return request;
+    }
+
+    public HttpServletResponse getResponse() {
+        return response;
     }
 }

--- a/src/test/java/io/swagger/inflector/controllers/SwaggerOperationControllerTest.java
+++ b/src/test/java/io/swagger/inflector/controllers/SwaggerOperationControllerTest.java
@@ -17,13 +17,25 @@
 package io.swagger.inflector.controllers;
 
 import com.google.common.collect.Maps;
+import io.swagger.inflector.config.Configuration;
+import io.swagger.inflector.models.RequestContext;
+import io.swagger.models.Model;
+import io.swagger.models.Operation;
 import org.testng.annotations.Test;
 
+import javax.inject.Provider;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.container.ContainerRequestContext;
+import java.util.Collections;
 import java.util.Map;
 
 import static java.io.File.separatorChar;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 
 public class SwaggerOperationControllerTest {
 
@@ -53,5 +65,36 @@ public class SwaggerOperationControllerTest {
 
         headers.put( "filename", separatorChar + "test.dat" + separatorChar + separatorChar + separatorChar );
         assertNull( SwaggerOperationController.extractFilenameFromHeaders( headers ));
+    }
+
+    @Test
+    public void testAddsRequestAndResponseToRequestContext() throws Exception {
+        final String remoteAddr = "10.11.12.13";
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn(remoteAddr);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        Provider<HttpServletRequest> requestProvider = new Provider<HttpServletRequest>() {
+            @Override
+            public HttpServletRequest get() {
+                return request;
+            }
+        };
+        Provider<HttpServletResponse> responseProvider = new Provider<HttpServletResponse>() {
+            @Override
+            public HttpServletResponse get() {
+                return response;
+            }
+        };
+        SwaggerOperationController controller = new SwaggerOperationController(mock(Configuration.class), "/any_path",
+                "GET", mock(Operation.class), Collections.<String, Model>emptyMap(),
+                requestProvider, responseProvider
+        );
+        ContainerRequestContext context = mock(ContainerRequestContext.class);
+
+        RequestContext requestContext = controller.createContext(context);
+
+        assertSame(requestContext.getRequest(), request);
+        assertSame(requestContext.getResponse(), response);
+        assertEquals(requestContext.getRemoteAddr(), remoteAddr);
     }
 }


### PR DESCRIPTION
In a vanilla JAX-RS application you can always get a reference to the HttpServletRequest and HttpServletResponse. This is very often useful, and it is problematic that these underlying objects are hidden from Swagger Inflector controllers, e.g. if you need to stream data to the client rather than build it in memory.

This PR make the request and response objects available via the new methods RequestContext.getRequest and RequestContext.getResponse.