### PR TITLE
Cache already processed properties/models (oas3) 

### DIFF
--- a/src/main/java/io/swagger/oas/inflector/examples/ExampleBuilder.java
+++ b/src/main/java/io/swagger/oas/inflector/examples/ExampleBuilder.java
@@ -446,6 +446,8 @@ public class ExampleBuilder {
                     }
                 }
             }
+        } else if (property.getAdditionalProperties() instanceof Boolean && output == null) {
+            output = new ObjectExample();
         }
         if (output != null) {
             if (attribute != null) {

--- a/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
+++ b/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
@@ -795,6 +795,37 @@ public class ExampleBuilderTest {
                 "}");
     }
 
+    @Test
+    public void verifyPropertyWithBooleanAdditionalProperty() throws Exception {
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/oas3.yaml");
+        ApiResponse response = openAPI.getPaths().get("/mockResponses/booleanAdditionalProperties").getGet().getResponses().get("200");
+
+        Example example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        String output = Json.pretty(example);
+        assertEqualsIgnoreLineEnding(output, "{\n" +
+                "  \"firstProperty\" : \"string\"\n" +
+                "}");
+    }
+
+    @Test
+    public void verifyBooleanAdditionalPropertyTrue() throws Exception {
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/oas3.yaml");
+        ApiResponse response = openAPI.getPaths().get("/mockResponses/booleanAdditionalPropertiesTrue").getGet().getResponses().get("200");
+
+        Example example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        String output = Json.pretty(example);
+        assertEqualsIgnoreLineEnding(output, "{ }");
+    }
+
+    @Test
+    public void verifyBooleanAdditionalPropertyFalse() throws Exception {
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/oas3.yaml");
+        ApiResponse response = openAPI.getPaths().get("/mockResponses/booleanAdditionalPropertiesFalse").getGet().getResponses().get("200");
+
+        Example example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        String output = Json.pretty(example);
+        assertEqualsIgnoreLineEnding(output, "{ }");
+    }
 
     @Test
     public void resolveComposedOneOfRefSchema(@Injectable List<AuthorizationValue> auth){

--- a/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
+++ b/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
@@ -745,6 +745,43 @@ public class ExampleBuilderTest {
     }
 
     @Test
+    public void verifyAdditionalPropertiesWithArray() throws Exception {
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/oas3_array.yaml");
+        ApiResponse response = openAPI.getPaths().get("/dictionaryOfArray").getGet().getResponses().get("200");
+
+        Example example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), openAPI.getComponents().getSchemas(), ExampleBuilder.RequestType.READ);
+        String output = Json.pretty(example);
+        assertEqualsIgnoreLineEnding(output, "{\n" +
+                "  \"additionalProp1\" : [ {\n" +
+                "    \"joel\" : \"string\",\n" +
+                "    \"prop2\" : 0\n" +
+                "  } ],\n" +
+                "  \"additionalProp2\" : [ {\n" +
+                "    \"joel\" : \"string\",\n" +
+                "    \"prop2\" : 0\n" +
+                "  } ],\n" +
+                "  \"additionalProp3\" : [ {\n" +
+                "    \"joel\" : \"string\",\n" +
+                "    \"prop2\" : 0\n" +
+                "  } ]\n" +
+                "}");
+    }
+
+    @Test
+    public void verifyAdditionalPropertiesWithPasswords() throws Exception {
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/oas3_password.yaml");
+        ApiResponse response = openAPI.getPaths().get("/dictionaryOfPassword").getGet().getResponses().get("200");
+
+        Example example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        String output = Json.pretty(example);
+        assertEqualsIgnoreLineEnding(output, "{\n" +
+                "  \"additionalProp1\" : \"string\",\n" +
+                "  \"additionalProp2\" : \"string\",\n" +
+                "  \"additionalProp3\" : \"string\"\n" +
+                "}");
+    }
+
+    @Test
     public void verifyGetMapResponse() throws Exception {
 
         OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/oas3.yaml");

--- a/src/test/swagger/oas3.yaml
+++ b/src/test/swagger/oas3.yaml
@@ -757,6 +757,30 @@ paths:
                 properties:
                   firstProperty:
                     type: string
+  "/mockResponses/booleanAdditionalPropertiesTrue":
+    get:
+      tags:
+        - mockResponses
+      responses:
+        '200':
+          description: success!
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+  "/mockResponses/booleanAdditionalPropertiesFalse":
+    get:
+      tags:
+        - mockResponses
+      responses:
+        '200':
+          description: success!
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
   "/mockResponses/complexResponse":
     get:
       tags:

--- a/src/test/swagger/oas3_array.yaml
+++ b/src/test/swagger/oas3_array.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info:
+  version: '1.0-oas3'
+  title: VirtServer additionalProperties test
+paths:
+  /dictionaryOfArray:
+    get:
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/myScheme'
+components:
+  schemas:
+    myScheme:
+      type: object
+      properties:
+        joel:
+          type: string
+        prop2:
+          type: integer
+# Added by API Auto Mocking Plugin
+servers:
+  - description: SwaggerHub API Auto Mocking
+    url: https://dev-virtserver.swaggerhub.com/0000/splat240_3/1.0-oas3

--- a/src/test/swagger/oas3_password.yaml
+++ b/src/test/swagger/oas3_password.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  version: '1.0-oas3'
+  title: VirtServer additionalProperties test
+paths:
+  /dictionaryOfPassword:
+    get:
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                  format: password
+
+# Added by API Auto Mocking Plugin
+servers:
+  - description: SwaggerHub API Auto Mocking
+    url: https://dev-virtserver.swaggerhub.com/0000/splat240_3/1.0-oas3


### PR DESCRIPTION
A continuation of #289 

Makes it possible to have $refs in additionalProperties and objects will be filled in (not only first object)