### PR TITLE
Dump parser warnings at startup

### DIFF
--- a/src/main/java/io/swagger/oas/inflector/OpenAPIInflector.java
+++ b/src/main/java/io/swagger/oas/inflector/OpenAPIInflector.java
@@ -117,8 +117,16 @@ public class OpenAPIInflector extends ResourceConfig {
         options.setResolve(true);
         options.setResolveFully(true);
         SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser().readLocation(config.getSwaggerUrl(), null, options);
+        
+        // Dump any warning messages the parser might produce
+        if (!swaggerParseResult.getMessages().isEmpty()) {
+            for (String message : swaggerParseResult.getMessages()) {
+                LOGGER.warn(message);
+            }
+        }
+        
         OpenAPI openAPI = swaggerParseResult.getOpenAPI();
-
+        
         if(!config.getValidatePayloads().isEmpty()) {
             LOGGER.info("resolving openAPI");
             new ExtensionsUtil().addExtensions(openAPI);


### PR DESCRIPTION
When starting up Inflector if there are any warning messages emitted by the parser dump them to as WARN level log messages so that users actually see them.

This is an enhancement to help avoid issues like #309 where users like myself waste a bunch of time debugging apparently correct specifications because Inflector is simply ignoring the parser warnings.  If the parser warnings had been logged from the start I could likely have spotted and corrected the root cause much faster.