### PR TITLE
Throw API error when Request Body fails to parse

### DIFF
--- a/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIOperationController.java
+++ b/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIOperationController.java
@@ -377,6 +377,16 @@ public class OpenAPIOperationController extends ReflectionUtils implements Infle
 
                             }
                         }
+                    } else if (operation.getRequestBody().getRequired()) {
+                        ValidationException e = new ValidationException();
+                        e.message(new ValidationMessage()
+                                .message("The input body `" + operation.getRequestBody() + "` is required but was provided with an unsupported media type `" + 
+                                            mediaType + "`"));
+                        try {
+                            throw e;
+                        } catch (ValidationException e1) {
+                            missingParams.add(e.getValidationMessage());
+                        }
                     }
                 } catch (ConversionException e) {
                     missingParams.add(e.getError());


### PR DESCRIPTION
There is a bug in the implementation of `OpenAPIOperationController.apply()` that means that it doesn't enforce a required request body in the case where a request body is supplied but is in an unsupported MIME type.  This adds the necessary else branch to the logic to throw an error in the case of a present but unsupported format request body.