### PR TITLE
Better parameter names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${maven-javadoc-version}</version>
                 <configuration>
                     <aggregate>true</aggregate>
                     <source>1.8</source>
@@ -260,7 +260,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
+                <version>${maven-javadoc-version}</version>
                 <configuration>
                     <aggregate>true</aggregate>
                     <debug>true</debug>
@@ -459,6 +459,7 @@
         </dependency>
     </dependencies>
     <properties>
+        <maven-javadoc-version>3.0.1</maven-javadoc-version>
         <swagger-core-version>2.1.0</swagger-core-version>
         <swagger-parser-version>2.0.16</swagger-parser-version>
         <jackson.version>2.10.1</jackson.version>

--- a/src/main/java/io/swagger/oas/inflector/OpenAPIInflector.java
+++ b/src/main/java/io/swagger/oas/inflector/OpenAPIInflector.java
@@ -358,7 +358,17 @@ public class OpenAPIInflector extends ResourceConfig {
                 }
             }
             final Resource.Builder builder = Resource.builder();
-            builder.path(basePath(originalBasePath, config.getSwaggerBase() + "debug.json"))
+            String debugPath;
+
+            if(config.getSwaggerBase().endsWith("/")) {
+                debugPath = basePath(originalBasePath, config.getSwaggerBase() + "debug.json");
+            }
+            else {
+                debugPath = basePath(originalBasePath, config.getSwaggerBase() + "/debug.json");
+            }
+
+            LOGGER.debug("using debug path: `" + debugPath + "`");
+            builder.path(debugPath)
                     .addMethod(HttpMethod.GET)
                     .produces(MediaType.APPLICATION_JSON)
                     .handledBy(new InflectResultController(result))

--- a/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIOperationController.java
+++ b/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIOperationController.java
@@ -158,7 +158,7 @@ public class OpenAPIOperationController extends ReflectionUtils implements Infle
     public Method detectMethod(Operation operation, String mediaType) {
         controllerName = getControllerName(operation);
         methodName = getMethodName(path, httpMethod, operation);
-        JavaType[] args = getOperationParameterClasses(operation, mediaType ,definitions);
+        JavaType[] args = getOperationParameterClasses(operation, mediaType, definitions);
 
         buildOperationSignature(args);
 
@@ -239,8 +239,9 @@ public class OpenAPIOperationController extends ReflectionUtils implements Infle
                         className = className.substring("java.lang.".length());
                     }
                     builder.append(className);
-                    builder.append(" ").append(args[i]);
 
+                    // TODO: we should really show the actual parameter name here
+                    builder.append(" ").append("p" + i);
                 }
             }
         }

--- a/src/test/java/io/swagger/oas/test/integration/SwaggerListingIT.java
+++ b/src/test/java/io/swagger/oas/test/integration/SwaggerListingIT.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
 
 public class SwaggerListingIT {
 
@@ -69,6 +70,27 @@ public class SwaggerListingIT {
                 "application/json",
                 null,
                 new String[0]);
+    }
+
+    @Test
+    public void verifyDebugJsonParameterNames() throws Exception {
+        ApiClient client = new ApiClient();
+        String response = client.invokeAPI("/swagger/debug.json",
+                "GET",
+                new HashMap<String, String>(),
+                null,
+                new HashMap<String, String>(),
+                null,
+                "application/json",
+                null,
+                new String[0]);
+
+        String [] substr = response.split("\"public ResponseContext updatePet");
+        assertTrue(substr.length > 1);
+
+        String signature = substr[1];
+        String paramName = signature.split("io.swagger.oas.sample.models.Pet", 2)[1].trim();
+        assertTrue(paramName.startsWith("p1"));
     }
 
     private void verifySwaggerExtensions(OpenAPI openAPI) {

--- a/src/test/java/io/swagger/oas/test/integration/SwaggerListingIT.java
+++ b/src/test/java/io/swagger/oas/test/integration/SwaggerListingIT.java
@@ -57,6 +57,20 @@ public class SwaggerListingIT {
         verifySwaggerExtensions(openAPI);
     }
 
+    @Test
+    public void verifyDebugJson() throws Exception {
+        ApiClient client = new ApiClient();
+        client.invokeAPI("/swagger/debug.json",
+                "GET",
+                new HashMap<String, String>(),
+                null,
+                new HashMap<String, String>(),
+                null,
+                "application/json",
+                null,
+                new String[0]);
+    }
+
     private void verifySwaggerExtensions(OpenAPI openAPI) {
         openAPI.getPaths().forEach((k, p) -> {
             if (p.getPost() != null && p.getPost().getExtensions() != null) {


### PR DESCRIPTION
This builds on #359, #361 

Improves the parameter names to be `p1`, `p2`, ..., `pn` instead of `String [simple type, class java.lang.String]`

It could be improved by extracting the parameter names from the definition as well as reaching into the complex parameters from the body.

Fixes #362 