### PR TITLE
Demonstrate AnonymousModel returned from XmlExampleSerializer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
     <properties>
         <maven-javadoc-version>3.0.1</maven-javadoc-version>
         <swagger-core-version>2.1.8</swagger-core-version>
-        <swagger-parser-version>2.0.25</swagger-parser-version>
+        <swagger-parser-version>2.0.27-SNAPSHOT</swagger-parser-version>
         <jackson.version>2.12.1</jackson.version>
         <jetty-version>9.4.39.v20210325</jetty-version>
         <jersey2-version>2.32</jersey2-version>

--- a/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
+++ b/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
 
 public class ExampleBuilderTest {
     static {
@@ -77,7 +78,23 @@ public class ExampleBuilderTest {
         Example example = ExampleBuilder.fromSchema(response.getContent().get("application/xml").getSchema(), openAPI.getComponents().getSchemas());
 
         String output = new XmlExampleSerializer().serialize(example);
+        assertFalse(output.contains("<AnonymousModel>"));
         assertEquals(output, "<?xml version='1.1' encoding='UTF-8'?><products><product><id>1</id><product>Lump Sum</product></product></products>");
+    }
+
+    @Test
+    public void testAllOfAndRefResolveFully(){
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/allOfAndRefResolveFully.yaml", null, options);
+
+        ApiResponse response = openAPI.getPaths().get("/inventory").getGet().getResponses().get( "200" );
+        Example example = ExampleBuilder.fromSchema(response.getContent().get("application/xml").getSchema(), openAPI.getComponents().getSchemas());
+
+        String output = new XmlExampleSerializer().serialize(example);
+        assertFalse(output.contains("<AnonymousModel>"));
+        assertEquals(output,"<?xml version='1.1' encoding='UTF-8'?><inventoryItem><supplierObject><name>ACME Corporation</name><supplierRef>REF123</supplierRef></supplierObject></inventoryItem>");
     }
 
     @Test
@@ -957,20 +974,6 @@ public class ExampleBuilderTest {
         String jsonExample = Json.pretty(example);
         assertTrue(jsonExample.contains("\"date\" : \"2019-08-05\""));
         assertTrue(jsonExample.contains("\"dateTime\" : \"2019-08-05T12:34:56Z\""));
-    }
-
-    @Test
-    public void testAllOfAndRefResolveFully(){
-        ParseOptions options = new ParseOptions();
-        options.setResolveFully(true);
-
-        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/allOfAndRefResolveFully.yaml", null, options);
-
-        ApiResponse response = openAPI.getPaths().get("/inventory").getGet().getResponses().get( "200" );
-        Example example = ExampleBuilder.fromSchema(response.getContent().get("application/xml").getSchema(), openAPI.getComponents().getSchemas());
-
-        String output = new XmlExampleSerializer().serialize(example);
-        assertEquals(output, "<?xml version='1.1' encoding='UTF-8'?><inventoryItem><suppliersArray><AnonymousModel><name>ACME Corporation</name><supplierRef>REF123</supplierRef></AnonymousModel></suppliersArray></inventoryItem>");
     }
    
     @Test

--- a/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
+++ b/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
@@ -944,4 +944,18 @@ public class ExampleBuilderTest {
         assertTrue(jsonExample.contains("\"date\" : \"2019-08-05\""));
         assertTrue(jsonExample.contains("\"dateTime\" : \"2019-08-05T12:34:56Z\""));
     }
+
+    @Test
+    public void testAllOfAndRefResolveFully(){
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/allOfAndRefResolveFully.yaml", null, options);
+
+        ApiResponse response = openAPI.getPaths().get("/inventory").getGet().getResponses().get( "200" );
+        Example example = ExampleBuilder.fromSchema(response.getContent().get("application/xml").getSchema(), openAPI.getComponents().getSchemas());
+
+        String output = new XmlExampleSerializer().serialize(example);
+        assertEquals(output, "<?xml version='1.1' encoding='UTF-8'?><inventoryItem><suppliersArray><AnonymousModel><name>ACME Corporation</name><supplierRef>REF123</supplierRef></AnonymousModel></suppliersArray></inventoryItem>");
+    }
 }

--- a/src/test/swagger/allOfAndRefResolveFully.yaml
+++ b/src/test/swagger/allOfAndRefResolveFully.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: test
+  version: 1.0.0
+paths:
+  /inventory:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/InventoryItem'
+components:
+  schemas:
+    InventoryItem:
+      type: object
+      properties:
+        suppliersArray:
+          type: array
+          items:
+            $ref: '#/components/schemas/Supplier'
+      xml:
+        name: inventoryItem
+    Manufacturer:
+      type: object
+      properties:
+        name:
+          type: string
+          example: ACME Corporation
+      xml:
+        name: manufacturer
+    Supplier:
+      allOf:
+        - $ref: '#/components/schemas/Manufacturer'
+        - type: object
+          properties:
+            supplierRef:
+              type: string
+              example: REF123
+      xml:
+        name: supplierObject


### PR DESCRIPTION
Added a unit test to demonstrate unexpected `AnonymousModel` tag when serializing fully resolved OpenAPI example using `XmlExampleSerializer`