### PR TITLE
Ignored null values from ExampleBuilder

### DIFF
--- a/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
+++ b/src/test/java/io/swagger/oas/test/examples/ExampleBuilderTest.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class ExampleBuilderTest {
@@ -943,5 +944,58 @@ public class ExampleBuilderTest {
         String jsonExample = Json.pretty(example);
         assertTrue(jsonExample.contains("\"date\" : \"2019-08-05\""));
         assertTrue(jsonExample.contains("\"dateTime\" : \"2019-08-05T12:34:56Z\""));
+    }
+
+    @Test
+    public void testNullExampleSupportOAS3(){
+
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        options.setResolveFully(true);
+
+        OpenAPI openAPI = new OpenAPIV3Parser().read("src/test/swagger/null-examples-oas3.yaml", null, options);
+
+        ApiResponse response = openAPI.getPaths().get("/object-with-null-example").getGet().getResponses().get("200");
+        Example example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        String output = Json.pretty(example);
+        assertNull(output);
+
+        response = openAPI.getPaths().get("/object-with-null-in-schema-example").getGet().getResponses().get("200");
+        example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        output = Json.pretty(example);
+        assertEquals(output, "{\n" +
+                "  \"a\" : 5,\n" +
+                "  \"b\" : \"test\",\n" +
+                "  \"c\" : true,\n" +
+                "  \"d\" : " + null + "\n" +
+                "}");
+
+        response = openAPI.getPaths().get("/object-with-null-property-example").getGet().getResponses().get("200");
+        example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        output = Json.pretty(example);
+        assertEquals(output, "{\n" +
+                "  \"a\" : 5,\n" +
+                "  \"b\" : " + null + "\n" +
+                "}");
+
+        response = openAPI.getPaths().get("/string-with-null-example").getGet().getResponses().get("200");
+        example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        output = Json.pretty(example);
+        assertNull(output);
+
+        response = openAPI.getPaths().get("/array-with-null-array-example").getGet().getResponses().get("200");
+        example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        output = Json.pretty(example);
+        assertNull(output);
+
+        response = openAPI.getPaths().get("/array-with-null-item-example").getGet().getResponses().get("200");
+        example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        output = Json.pretty(example);
+        assertEquals(output, "[" + null + "]");
+
+        response = openAPI.getPaths().get("/array-with-null-in-array-example").getGet().getResponses().get("200");
+        example = ExampleBuilder.fromSchema(response.getContent().get("application/json").getSchema(), null, ExampleBuilder.RequestType.READ);
+        output = Json.pretty(example);
+        assertEquals(output, "[\"foo\", " + null + "]");
     }
 }

--- a/src/test/swagger/null-examples-oas3.yaml
+++ b/src/test/swagger/null-examples-oas3.yaml
@@ -1,0 +1,138 @@
+openapi: 3.0.2
+info:
+  title: null examples
+  version: 1.0.0
+paths:
+
+  /object-with-null-example:
+    get:
+      description: Response should be `null`
+      responses:
+        '200':
+          description: Should be `null`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithNullExample'
+
+  /object-with-null-in-schema-example:
+    get:
+      description: 'Response should be `{..., "d": null}`'
+      responses:
+        '200':
+          description: 'Should be `{..., "d": null}`'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithNullInSchemaExample'
+
+  /object-with-null-property-example:
+    get:
+      description: 'Response should be `{"a": 5, "b": null}`'
+      responses:
+        '200':
+          description: 'Should be `{"a": 5, "b": null}`'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithNullPropertyExample'
+
+  /string-with-null-example:
+    get:
+      description: Response should be `null`
+      responses:
+        '200':
+          description: Should be `null`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringWithNullExample'
+
+  /array-with-null-array-example:
+    get:
+      description: Response should be `null`
+      responses:
+        '200':
+          description: Should be `null`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrayWithNullArrayExample'
+
+  /array-with-null-item-example:
+    get:
+      description: Response should be `[null]`
+      responses:
+        '200':
+          description: Should be `[null]`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrayWithNullItemExample'
+
+  /array-with-null-in-array-example:
+    get:
+      description: Response should be `["foo", null]`
+      responses:
+        '200':
+          description: Should be `["foo", null]`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrayWithNullInArrayExample'
+
+components:
+  schemas:
+
+    ObjectWithNullExample:
+      type: object
+      properties:
+        foo:
+          type: string
+      nullable: true
+      example: null
+
+    ObjectWithNullInSchemaExample:
+      type: object
+      example:
+        a: 5
+        b: test
+        c: true
+        d: null
+
+    ObjectWithNullPropertyExample:
+      type: object
+      properties:
+        a:
+          type: integer
+          example: 5
+        b:
+          type: string
+          nullable: true
+          example: null
+
+    StringWithNullExample:
+      type: string
+      nullable: true
+      example: null
+
+    ArrayWithNullArrayExample:
+      type: array
+      items:
+        type: string
+      nullable: true
+      example: null
+
+    ArrayWithNullItemExample:
+      type: array
+      items:
+        type: string
+        nullable: true
+        example: null
+
+    ArrayWithNullInArrayExample:
+      type: array
+      items:
+        type: string
+        nullable: true
+      example: [foo, null]


### PR DESCRIPTION
Add unit test to demonstrate behavior where null values returned from `ExampleBuilder` are either ignored and returned as the default `"string"` value or as string of value `"null"`