### PR TITLE
Added operation passthrough in RequestContext

### DIFF
--- a/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIOperationController.java
+++ b/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIOperationController.java
@@ -255,6 +255,7 @@ public class OpenAPIOperationController extends ReflectionUtils implements Infle
         List<Parameter> parameters = operation.getParameters();
 
         final RequestContext requestContext = createContext(ctx);
+        requestContext.setOperation(operation);
         Map<String, File> inputStreams = new HashMap<>();
 
         Object[] args = new Object[parameterClasses.length];

--- a/src/main/java/io/swagger/oas/inflector/models/RequestContext.java
+++ b/src/main/java/io/swagger/oas/inflector/models/RequestContext.java
@@ -16,18 +16,23 @@
 
 package io.swagger.oas.inflector.models;
 
+import io.swagger.v3.oas.models.Operation;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class RequestContext {
     ContainerRequestContext context;
     MultivaluedMap<String, String> headers;
     MediaType mediaType;
     List<MediaType> acceptableMediaTypes;
+    private Operation operation;
     private String remoteAddr;
     private final HttpServletRequest request;
     private final HttpServletResponse response;
@@ -52,6 +57,26 @@ public class RequestContext {
             this.remoteAddr = request.getRemoteAddr();
         }
         this.response = response;
+    }
+
+    public RequestContext operation(Operation operation) {
+        this.operation = operation;
+        return this;
+    }
+
+    public Operation getOperation() {
+        return this.operation;
+    }
+
+    public void setOperation(Operation operation) {
+        this.operation = operation;
+    }
+
+    public Map<String, Object> getExtensions() {
+        if(operation != null && operation.getExtensions() != null) {
+            return operation.getExtensions();
+        }
+        return new HashMap<>();
     }
 
     public RequestContext headers(MultivaluedMap<String, String> headers) {

--- a/src/test/java/io/swagger/oas/sample/controllers/TestController.java
+++ b/src/test/java/io/swagger/oas/sample/controllers/TestController.java
@@ -73,6 +73,12 @@ public class TestController {
     }
 
     public ResponseContext updatePet(RequestContext request, com.fasterxml.jackson.databind.JsonNode petType) {
+        if(request.getOperation() != null && request.getExtensions().containsKey("x-sample-extension")) {
+            String message = request.getExtensions().get("x-sample-extension").toString();
+            return new ResponseContext()
+                    .status(200)
+                    .entity(message);
+        }
         return new ResponseContext()
                 .status(200)
                 .entity("OK!");

--- a/src/test/java/io/swagger/oas/test/integration/RequestTestIT.java
+++ b/src/test/java/io/swagger/oas/test/integration/RequestTestIT.java
@@ -47,19 +47,20 @@ public class RequestTestIT {
     
     @Test
     public void verifyUpdatePet() throws Exception {
-        String path = "/pets";
+        String path = "/pet";
         Map<String,String> body = new HashMap<>();
-        body.put("pet_type","Cat");
-        Response response = client.getResponse(path, "POST", new HashMap<String, String>(), body, new HashMap<String, String>(), null, "application/json", null, new String[0]);
+        body.put("id", "10");
+        body.put("name","Cat");
+        Response response = client.getResponse(path, "PUT", new HashMap<String, String>(), body, new HashMap<String, String>(), null, "application/json", null, new String[0]);
         assertNotNull(response.getCookies());
-        assertEquals(1, response.getCookies().size());
+        assertEquals(response.getCookies().size(), 1);
         NewCookie cookie = response.getCookies().get("type");
-        assertEquals("type", cookie.getName());
-        assertEquals("chocolate", cookie.getValue());
+        assertEquals(cookie.getName(), "type");
+        assertEquals(cookie.getValue(), "chocolate");
     }
 
     @Test
-    public void verifyUpdatePet() throws Exception {
+    public void verifyUpdatePetWithNullBody() throws Exception {
         String path = "/pets";
         String str = client.invokeAPI(path, "POST", new HashMap<String, String>(), null, new HashMap<String, String>(), null, "application/json", null, new String[0]);
         assertEquals(str, "OK!");

--- a/src/test/java/io/swagger/oas/test/integration/SwaggerListingIT.java
+++ b/src/test/java/io/swagger/oas/test/integration/SwaggerListingIT.java
@@ -85,11 +85,11 @@ public class SwaggerListingIT {
                 null,
                 new String[0]);
 
-        String [] substr = response.split("\"public ResponseContext updatePet");
+        String [] substr = response.split("\"public ResponseContext addPet");
         assertTrue(substr.length > 1);
 
         String signature = substr[1];
-        String paramName = signature.split("io.swagger.oas.sample.models.Pet", 2)[1].trim();
+        String paramName = signature.split("io.swagger.oas.sample.models.Dog", 2)[1].trim();
         assertTrue(paramName.startsWith("p1"));
     }
 

--- a/src/test/swagger/oas3.yaml
+++ b/src/test/swagger/oas3.yaml
@@ -307,7 +307,7 @@ paths:
   /pets:
     post:
       x-swagger-router-controller: TestController
-      operationId: updatePet
+      operationId: updatePetByType
       requestBody:
         content:
           application/json:
@@ -428,6 +428,7 @@ paths:
       tags:
       - pet
       x-sample-extension: "it works!"
+      x-swagger-router-controller: TestController
       summary: Update an existing pet
       description: ''
       operationId: updatePet

--- a/src/test/swagger/oas3.yaml
+++ b/src/test/swagger/oas3.yaml
@@ -427,6 +427,7 @@ paths:
     put:
       tags:
       - pet
+      x-sample-extension: "it works!"
       summary: Update an existing pet
       description: ''
       operationId: updatePet


### PR DESCRIPTION
Now we can use the operation RequestContext to enforce security, pass definitions via extensions, profit