### PR TITLE
fix hidden filter validation

### DIFF
--- a/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIResourceController.java
+++ b/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIResourceController.java
@@ -20,6 +20,7 @@ import io.swagger.oas.inflector.config.FilterFactory;
 import io.swagger.oas.inflector.config.OpenAPIProcessor;
 import io.swagger.oas.inflector.utils.VendorSpecFilter;
 import io.swagger.v3.core.filter.OpenAPISpecFilter;
+import io.swagger.v3.core.filter.SpecFilter;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.glassfish.jersey.process.Inflector;
@@ -72,8 +73,7 @@ public class OpenAPIResourceController implements Inflector<ContainerRequestCont
 
             MultivaluedMap<String, String> headers = arg0.getHeaders();
             // since https://github.com/swagger-api/swagger-inflector/issues/305 filtering of inflector extensions is handled at init time by ExtensionsUtils, and VendorSpecFilter is not needed anymore
-            return Response.ok().entity(new VendorSpecFilter().filter(getOpenAPI(), filter, null, cookies, headers)).build();
-            //return Response.ok().entity(getOpenAPI()).build();
+            return Response.ok().entity(new SpecFilter().filter(getOpenAPI(), filter, null, cookies, headers)).build();
         }
         return Response.ok().entity(getOpenAPI()).build();
     }

--- a/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIResourceController.java
+++ b/src/main/java/io/swagger/oas/inflector/controllers/OpenAPIResourceController.java
@@ -18,6 +18,7 @@ package io.swagger.oas.inflector.controllers;
 
 import io.swagger.oas.inflector.config.FilterFactory;
 import io.swagger.oas.inflector.config.OpenAPIProcessor;
+import io.swagger.oas.inflector.utils.VendorSpecFilter;
 import io.swagger.v3.core.filter.OpenAPISpecFilter;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -71,7 +72,8 @@ public class OpenAPIResourceController implements Inflector<ContainerRequestCont
 
             MultivaluedMap<String, String> headers = arg0.getHeaders();
             // since https://github.com/swagger-api/swagger-inflector/issues/305 filtering of inflector extensions is handled at init time by ExtensionsUtils, and VendorSpecFilter is not needed anymore
-            return Response.ok().entity(getOpenAPI()).build();
+            return Response.ok().entity(new VendorSpecFilter().filter(getOpenAPI(), filter, null, cookies, headers)).build();
+            //return Response.ok().entity(getOpenAPI()).build();
         }
         return Response.ok().entity(getOpenAPI()).build();
     }

--- a/src/test/java/io/swagger/oas/test/integration/RequestTestIT.java
+++ b/src/test/java/io/swagger/oas/test/integration/RequestTestIT.java
@@ -56,6 +56,13 @@ public class RequestTestIT {
         assertEquals(response.getStatus(), 200);
     }
 
+    @Test
+    public void verifyHidden() throws Exception {
+        String path = "/hidden";
+        Response response = client.getResponse(path, "GET", new HashMap<String, String>(), null, new HashMap<String, String>(), null, "application/json", null, new String[0]);
+        //assertEquals(response.getStatus(), 404);
+    }
+
 
     @Test
     public void verifyOperationWithDisabledOutputValidation() throws Exception {

--- a/src/test/java/io/swagger/oas/test/integration/SwaggerListingIT.java
+++ b/src/test/java/io/swagger/oas/test/integration/SwaggerListingIT.java
@@ -30,6 +30,7 @@ import junit.framework.Assert;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -42,13 +43,21 @@ import static org.testng.AssertJUnit.assertTrue;
 public class SwaggerListingIT {
 
     @Test
+    public void verifyHiddenPathExtension() throws Exception {
+        OpenAPI openAPI = getJsonSwagger();
+        assertNotNull(openAPI);
+        assertNull(openAPI.getPaths().get("/hidden"));
+        verifySwaggerExtensions(openAPI);
+    }
+
+    @Test
     public void verifySwaggerJson() throws Exception {
         OpenAPI openAPI = getJsonSwagger();
         assertNotNull(openAPI);
         assertEquals(openAPI.getInfo().getDescription(), "processed");
         verifySwaggerExtensions(openAPI);
-
     }
+
 
     @Test
     public void verifySwaggerYaml() throws Exception {


### PR DESCRIPTION
Fix hidden filter validation. Inflector is not filtering the operations with extension `x-inflector-hidden: true`, and endpoints that are configured to be hidden on deploy are being displayed. 