### PR TITLE
Guard against NPE in the ExtensionsUtil class

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,13 @@ The samples are a being refactor to support the new inflector.
 
 You will soon find samples for the inflector project in the [Swagger-Samples](https://github.com/swagger-api/swagger-samples) repository.  The inflector projects start with `inflector-`
 
+#### Running tests
+
+If running Java 8, you will need to run a variant that has backported fix 8157236. Azul Zulu is confirmed to work (https://github.com/jmockit/jmockit1/issues/710).
+
+If running with Java 9 or later, you will need to either:
+- Pass `-Djdk.attach.allowAttachSelf=true` to the VM.
+- Configure the test execution JVM to start with the "-javaagent:<proper path>/jmockit.1.x.jar" initialization parameter. It can be specified in the build script file for tools such as Maven or Gradle, or in a "Run/Debug Configuration" for IntelliJ IDEA or Eclipse.
 
 ## Security contact
 

--- a/src/main/java/io/swagger/oas/inflector/utils/ExtensionsUtil.java
+++ b/src/main/java/io/swagger/oas/inflector/utils/ExtensionsUtil.java
@@ -2,7 +2,6 @@ package io.swagger.oas.inflector.utils;
 
 import io.swagger.oas.inflector.Constants;
 
-import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
@@ -11,8 +10,6 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
-import org.slf4j.LoggerFactory;
-
 
 import java.util.HashMap;
 import java.util.Map;
@@ -92,8 +89,9 @@ public class ExtensionsUtil {
                             for (String name : schemas.keySet()) {
                                 Schema schema = schemas.get(name);
                                 if (resolved.equals(schema)){
-                                    final String constant = (String) schema.getExtensions().get(Constants.X_SWAGGER_ROUTER_MODEL);
-                                    if (constant != null) {
+                                    final Map constants = schema.getExtensions();
+                                    if (constants != null) {
+                                        final String constant = (String) constants.get(Constants.X_SWAGGER_ROUTER_MODEL);
                                         if (addExtensions) {
                                             resolved.addExtension(Constants.X_SWAGGER_ROUTER_MODEL, constant);
                                         }else {
@@ -114,8 +112,9 @@ public class ExtensionsUtil {
                                     for (String name : schemas.keySet()) {
                                         Schema schema = schemas.get(name);
                                         if (resolved.equals(schema)){
-                                            final String constant = (String) schema.getExtensions().get(Constants.X_SWAGGER_ROUTER_MODEL);
-                                            if (constant != null) {
+                                            final Map constants = schema.getExtensions();
+                                            if (constants != null) {
+                                                final String constant = (String) constants.get(Constants.X_SWAGGER_ROUTER_MODEL);
                                                 if (addExtensions) {
                                                     resolved.addExtension(Constants.X_SWAGGER_ROUTER_MODEL, constant);
                                                 }else {
@@ -158,8 +157,9 @@ public class ExtensionsUtil {
                                 Schema schema = schemas.get(name);
                                 if (resolved.equals(schema)){
                                     if (schema.getExtensions() != null){
-                                        final String constant = (String) schema.getExtensions().get(Constants.X_SWAGGER_ROUTER_MODEL);
-                                        if (constant != null) {
+                                        final Map constants = schema.getExtensions();
+                                        if (constants != null) {
+                                            final String constant = (String) constants.get(Constants.X_SWAGGER_ROUTER_MODEL);
                                             if (addExtensions) {
                                                 resolved.addExtension(Constants.X_SWAGGER_ROUTER_MODEL, constant);
                                             } else {
@@ -188,8 +188,9 @@ public class ExtensionsUtil {
                                         Schema schema = schemas.get(name);
                                         if (resolved.equals(schema)){
                                             if (schema.getExtensions() != null) {
-                                                final String constant = (String) schema.getExtensions().get(Constants.X_SWAGGER_ROUTER_MODEL);
-                                                if (constant != null) {
+                                                final Map constants = schema.getExtensions();
+                                                if (constants != null) {
+                                                    final String constant = (String) constants.get(Constants.X_SWAGGER_ROUTER_MODEL);
                                                     if (addExtensions) {
                                                         resolved.addExtension(Constants.X_SWAGGER_ROUTER_MODEL, constant);
                                                     } else {


### PR DESCRIPTION
Sometimes during `resolvePath()`, the schemas do not already have extensions associated with them. This is to prevent an NPE from being thrown when looking for them.