### PR TITLE
fix: duplicate authorization header caused by using both GH_TOKEN and…

### DIFF
--- a/.github/workflows/next-snapshot-v1.yml
+++ b/.github/workflows/next-snapshot-v1.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - uses: tibdex/github-app-token@v2
         id: generate-token
         with:
@@ -62,6 +65,7 @@ jobs:
         with:
           ref: "v1"
           fetch-depth: 0
+          persist-credentials: false
       - name: Run next snapshot script
         id: postRelease
         if: env.RELEASE_OK == 'yes'

--- a/.github/workflows/next-snapshot.yml
+++ b/.github/workflows/next-snapshot.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - uses: tibdex/github-app-token@v2
         id: generate-token
         with:
@@ -62,6 +65,7 @@ jobs:
         with:
           ref: "master"
           fetch-depth: 0
+          persist-credentials: false
       - name: Run next snapshot script
         id: postRelease
         if: env.RELEASE_OK == 'yes'

--- a/.github/workflows/prepare-release-v1.yml
+++ b/.github/workflows/prepare-release-v1.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+        fetch-depth: 0
     - uses: tibdex/github-app-token@v2
       id: generate-token
       with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+        fetch-depth: 0
     - uses: tibdex/github-app-token@v2
       id: generate-token
       with:

--- a/.github/workflows/release-v1.yml
+++ b/.github/workflows/release-v1.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+        fetch-depth: 0
     - uses: tibdex/github-app-token@v2
       id: generate-token
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+        fetch-depth: 0
     - uses: tibdex/github-app-token@v2
       id: generate-token
       with:


### PR DESCRIPTION
Fixed the duplicate authorization header issue by adding `persist-credentials: false` and f`etch-depth: 0 `to the `checkout` step. This prevents the checkout action from persisting Git credentials, which was causing conflicts with the GitHub App token and GH_TOKEN environment variable.