### PR TITLE
chore: update logback to 1.5.34 and SLF4J to  2.0.18 for compatibility with logback 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -533,9 +533,9 @@
         <commons-csv-version>1.10.0</commons-csv-version>
         <json-schema-validator-version>2.2.14</json-schema-validator-version>
 
-        <logback-version>1.5.25</logback-version>
+        <logback-version>1.5.34</logback-version>
         <junit-version>4.13.2</junit-version>
-        <slf4j-version>1.7.36</slf4j-version>
+        <slf4j-version>2.0.18</slf4j-version>
         <jmockit-version>1.49</jmockit-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -178,9 +178,9 @@
     </dependencies>
     <properties>
         <jetty-version>12.0.14</jetty-version>
-        <logback-version>1.5.22</logback-version>
+        <logback-version>1.5.34</logback-version>
         <junit-version>4.13.2</junit-version>
-        <slf4j-version>1.7.36</slf4j-version>
+        <slf4j-version>2.0.18</slf4j-version>
         <codegen-version>2.1.4</codegen-version>
     </properties>
 </project>


### PR DESCRIPTION
Changes:
  - Updated Logback `1.5.25` → `1.5.37`
  - Updated SLF4J `1.7.36 `→ `2.0.18 `for Logback 1.5 compatibility